### PR TITLE
Add `isDirty` definition for `useForm` hook

### DIFF
--- a/packages/inertia-react/index.d.ts
+++ b/packages/inertia-react/index.d.ts
@@ -67,6 +67,7 @@ type setDataByKeyValuePair<TForm> = <K extends keyof TForm>(key: K, value: TForm
 
 export interface InertiaFormProps<TForm = Record<string, any>> {
 	data: TForm
+	isDirty: boolean
 	errors: Record<keyof TForm, string>
 	hasErrors: boolean
 	processing: boolean


### PR DESCRIPTION
Just adding `isDirty` type definition for the `useForm` hook in the React adapter.